### PR TITLE
Project logic improvement for Scroll: Update Verifier Contracts to account for Darwin upgrade

### DIFF
--- a/queries/scroll_verification_base___3916549.sql
+++ b/queries/scroll_verification_base___3916549.sql
@@ -27,8 +27,8 @@ where 1=1
         0x4B8Aa8A96078689384DAb49691E9bA51F9d2F9E1 -- L1_PLONK_VERIFIER_V0_ADDR
         , 0x2293cd12e8564e8219d314b075867c2f66ac6941 -- L1_PLONK_VERIFIER_V1_ADDR
         , 0x03a72B00D036C479105fF98A1953b15d9c510110 -- L1_PLONK_VERIFIER_V2_ADDR
-        , 0x2d6e16d8e8a0C3Bc7750E774B108Ec39Ab0C18fB -- L1_PLONK_VERIFIER_V3_ADDR
-        , 0xCAECeE2E815e7f758c2477f900AFA14bDDce54B3 -- L1_PLONK_VERIFIER_V4_ADDR
+        , 0x8759E83b6570A0bA46c3CE7eB359F354F816c9a9 -- L1_PLONK_VERIFIER_V3_ADDR
+        , 0x8c1b52757b5c571ADcB5572E992679d4D48e30f7 -- L1_PLONK_VERIFIER_V4_ADDR
     )
     and tr.call_type = 'staticcall' -- assuming that verifier contract should be called as readonly staticcalls (next best to identifying all verifier contracts which is pretty impossible manually)
     

--- a/queries/scroll_verification_base___3916549.sql
+++ b/queries/scroll_verification_base___3916549.sql
@@ -27,6 +27,8 @@ where 1=1
         0x4B8Aa8A96078689384DAb49691E9bA51F9d2F9E1 -- L1_PLONK_VERIFIER_V0_ADDR
         , 0x2293cd12e8564e8219d314b075867c2f66ac6941 -- L1_PLONK_VERIFIER_V1_ADDR
         , 0x03a72B00D036C479105fF98A1953b15d9c510110 -- L1_PLONK_VERIFIER_V2_ADDR
+        , 0x2d6e16d8e8a0C3Bc7750E774B108Ec39Ab0C18fB -- L1_PLONK_VERIFIER_V3_ADDR
+        , 0xCAECeE2E815e7f758c2477f900AFA14bDDce54B3 -- L1_PLONK_VERIFIER_V4_ADDR
     )
     and tr.call_type = 'staticcall' -- assuming that verifier contract should be called as readonly staticcalls (next best to identifying all verifier contracts which is pretty impossible manually)
     


### PR DESCRIPTION
| Original | Updated | Change | Reasoning |
|---|---|---|---|
| [3916549](https://dune.com/queries/3916549) | [4081291](https://dune.com/queries/4081291) (my fork) | Add new verifier contracts deployed in [Darwin upgrade](https://scroll.io/blog/proof-recursion-scrolls-darwin-upgrade) | Current query doesn't work past 8/21 (date of Darwin upgrade) |

**Find new ZkEvmVerifierV2 deployments:**
https://etherscan.io/address/0x4CEA3E866e7c57fD75CB0CA3E9F5f1151D4Ead3F#readContract#F1

<img width="422" alt="Screenshot 2024-09-18 at 12 08 47 PM" src="https://github.com/user-attachments/assets/8c715a1f-6fbf-458e-b983-6e69b51c8bce">

New [ZkEvmVerifierV2](https://etherscan.io/address/0x2d6e16d8e8a0C3Bc7750E774B108Ec39Ab0C18fB) - deployed 8/21

<img width="411" alt="Screenshot 2024-09-18 at 12 08 55 PM" src="https://github.com/user-attachments/assets/3c124857-aada-4ab8-9332-2483cae9ac5b">

Newer [ZkEvmVerifierV2](https://etherscan.io/address/0xCAECeE2E815e7f758c2477f900AFA14bDDce54B3) - deployed 8/29

**Find new PLONK Verifier contract deployments from new ZkEvmVerifierV2 contracts:**

https://etherscan.io/address/0x2d6e16d8e8a0c3bc7750e774b108ec39ab0c18fb#readContract#F1
<img width="425" alt="Screenshot 2024-09-18 at 12 17 34 PM" src="https://github.com/user-attachments/assets/5dc4c4ad-3201-479d-9059-57dfeeb7eecf">

New PLONK verifier [0x8759E83b6570A0bA46c3CE7eB359F354F816c9a9](https://etherscan.io/address/0x8759E83b6570A0bA46c3CE7eB359F354F816c9a9)


https://etherscan.io/address/0xCAECeE2E815e7f758c2477f900AFA14bDDce54B3#readContract#F1
<img width="391" alt="Screenshot 2024-09-18 at 12 17 56 PM" src="https://github.com/user-attachments/assets/1c863b97-67f3-4a5c-ab21-bba1963309b7">

Newer PLONK verifier [0x8c1b52757b5c571ADcB5572E992679d4D48e30f7](https://etherscan.io/address/0x8c1b52757b5c571ADcB5572E992679d4D48e30f7)


Latest results on current query:
<img width="1179" alt="Screenshot 2024-09-18 at 12 23 48 PM" src="https://github.com/user-attachments/assets/a7004909-f15f-4804-baff-c16889768415">

Latest results on updated query (from 9/18):
<img width="972" alt="Screenshot 2024-09-18 at 12 23 39 PM" src="https://github.com/user-attachments/assets/cea74bdb-aa8e-4bbd-bbb2-73c2bab35ced">


---