### PR TITLE
update scroll & linea queries

### DIFF
--- a/queries/linea_verification_base___3916566.sql
+++ b/queries/linea_verification_base___3916566.sql
@@ -36,7 +36,8 @@ left join eth_usd_price ep on tr.block_date = ep.day
 left join eth_gas_price gp on tr.block_date = gp.day
 WHERE tx.to = 0xd19d4B5d358258f05D7B411E21A1460D11B0876F -- Linea L1 Message Service
         AND (bytearray_substring(tx.data, 1, 4) = 0xd630280f -- finalizeCompressedBlocksWithProof -- https://etherscan.io/tx/0xdfd79401c75f370e4a742223c1f553d934ec6903106cde1f1b6814dc5825bb15/advanced#internal
-            OR bytearray_substring(tx.data, 1, 4) = 0x4165d6dd -- finalizeBlocks -- https://etherscan.io/tx/0x750cf2a6239e1fee1f04b6d66fa93822ce2b4ae4d81e84035f1dc313391e512a/advanced#internal
+            OR bytearray_substring(tx.data, 1, 4) = 0x4165d6dd -- finalizeBlocks (old contract) -- https://etherscan.io/tx/0x750cf2a6239e1fee1f04b6d66fa93822ce2b4ae4d81e84035f1dc313391e512a/advanced#internal
+            OR bytearray_substring(tx.data, 1, 4) = 0x5603c65f -- finalizeBlocks (current contract) -- https://etherscan.io/tx/0x006a303e87fef08c09f35a83c535e916e990e1f115d420a768499dac46a28627/advanced
             OR bytearray_substring(tx.data, 1, 4) = 0xabffac32 -- finalizeBlocksWithProof -- https://etherscan.io/tx/0x11a41718c21e2aa3c7052b99938b26ac366a30ba00aad0a7b5dff63bfe0309b1/advanced#internal
             )
     and tr.to in ( -- Verifier contracts

--- a/queries/scroll_verification_base___3916549.sql
+++ b/queries/scroll_verification_base___3916549.sql
@@ -23,7 +23,10 @@ left join ethereum.traces tr on tr.block_number = tx.block_number and tr.tx_hash
 left join eth_usd_price ep on tr.block_date = ep.day
 where 1=1
     -- and varbinary_substring(tx.data, 1, 4) = 0x00b0f4d7 -- finalizeBatchWithProof4844, not needed
-    and tx."from" = 0x356483dC32B004f32Ea0Ce58F7F88879886e9074 -- bathch finalizer, per Scroll team this is the correct address
+    and tx."from" in (
+        0x356483dC32B004f32Ea0Ce58F7F88879886e9074, -- old batch finalizer, per Scroll team this is the correct address
+        0x6f9d816c4ec365fe8fc6898c785be0e2d51bec2c -- current batch finalizer https://etherscan.io/accounts/label/scroll
+    )
     and tr.to in ( -- filter for calls to the actual proof verifier 
         0x4B8Aa8A96078689384DAb49691E9bA51F9d2F9E1 -- L1_PLONK_VERIFIER_V0_ADDR
         , 0x2293cd12e8564e8219d314b075867c2f66ac6941 -- L1_PLONK_VERIFIER_V1_ADDR


### PR DESCRIPTION
| Original | Updated | Change | Reasoning |
|---|---|---|---|
| [3916549](https://dune.com/queries/3916549) | [4081291](https://dune.com/queries/4081291) (my working query fork) | Add [new Scroll Batch Finalizer Contract](https://etherscan.io/address/0x6f9d816c4ec365fe8fc6898c785be0e2d51bec2c) | Previous Batch Finalizer stopped submitting batches on 12/23/24 |
| [3916566](https://dune.com/queries/3916566) | [4540633](https://dune.com/queries/4540633) (my working query fork) | Update selector for finalizeBlocks | New [LineaRollup Implementation](https://etherscan.io/address/0x07ddce60658a61dc1732cacf2220fce4a01c49b0#writeContract) has an updated selector for finalizeBlocks |

**Provide any other context or screenshots that explain or justify the changes above:**

Scroll Change:
The Scroll [query](https://dune.com/queries/3916549) has no results after 12/23. Scroll started using a new Batch Finalizer Contract ([0x6f9d816c4ec365fe8fc6898c785be0e2d51bec2c](https://etherscan.io/address/0x6f9d816c4ec365fe8fc6898c785be0e2d51bec2c)) on 12/23. The query is updated to collect metrics for transactions coming from the old contract and the new one. 


Linea Change:
The Linea [query](https://dune.com/queries/3916566) has no results after 12/16. The latest implementation ([0x07ddce60658A61dc1732Cacf2220FcE4A01C49B0](https://etherscan.io/address/0x07ddce60658a61dc1732cacf2220fce4a01c49b0#writeContract)) has a new selector for finalizeBlocks ([0x5603c65f](https://etherscan.io/address/0xd19d4B5d358258f05D7B411E21A1460D11B0876F#writeProxyContract#F3)). The query is updated to include the new selector.

<img width="235" alt="Screenshot 2025-01-08 at 3 08 30 PM" src="https://github.com/user-attachments/assets/f627184d-ec55-4b31-8d79-8683d8047d74" />


The upgrade happened on 12/16 ([Linea Release Notes](https://docs.linea.build/release-notes#alpha-v4)).
